### PR TITLE
Reassign Nodejitsu copyright to the Contributors. Attribute the contributors.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2013 by Nodejitsu, Maciej Małecki
+Copyright (C) 2013 Charlie Robbins, Maciej Małecki, Jarrett Cruger, & the Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pkgcloud-bootstrapper
-`pkgcloud.compute.Bootstrapper` extracted into its own module.
+
+`pkgcloud.compute.Bootstrapper` extracted into its own module. Originally found in [pkgcloud core](https://github.com/pkgcloud/pkgcloud/blob/v0.8.17/lib/pkgcloud/core/compute/bootstrapper.js) in `pkgcloud@<=0.8.17`
 
 ## Usage
 


### PR DESCRIPTION
Corresponding PR to https://github.com/pkgcloud/pkgcloud/pull/417

> Been meaning to do this for a while. Thought I would get it done before I probably say @kenperkins at SeattleJS tonight :sunglasses:
